### PR TITLE
Fix test:coverage to use pest instead of phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,14 @@
                     "override": true,
                     "script": "pest"
                 },
+                "test:coverage:ci": {
+                    "override": true,
+                    "script": "pest --colors=always --coverage-clover build/coverage/clover.xml --coverage-xml build/coverage/coverage-xml --log-junit build/coverage/junit.xml"
+                },
+                "test:coverage:html": {
+                    "override": true,
+                    "script": "pest --colors=always --coverage-html build/coverage/coverage-html"
+                },
                 "lint": {
                     "override": true,
                     "script": "phpcs --cache=./var/cache/phpcs.cache"


### PR DESCRIPTION
Just override the original test:coverage:ci and test:coverage:html to use pest